### PR TITLE
Specify what's the npm package name for this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 This is a tiny library that mirrors IndexedDB, but replaces the weird `IDBRequest` objects with promises, plus a couple of other small changes.
 
+## Usage
+
+You can find `indexeddb-promised` as `idb` in npm. With Browserify or Webpack with Babel:
+
+```sh
+npm install --save idb
+```
+
+Then you can import and use it.
+
+```js
+import idb from 'idb';
+
+const dbPromise = idb.open('my-store');
+...
+```
+
 # Examples
 
 ## Keyval Store

--- a/README.md
+++ b/README.md
@@ -4,19 +4,16 @@ This is a tiny library that mirrors IndexedDB, but replaces the weird `IDBReques
 
 ## Usage
 
-You can find `indexeddb-promised` as `idb` in npm. With Browserify or Webpack and Babel:
+You can find `indexeddb-promised` as `idb` in npm:
 
 ```sh
 npm install --save idb
 ```
 
-Then you can import and use it.
+Then you can import (or require) and use it.
 
 ```js
 import idb from 'idb';
-
-const dbPromise = idb.open('my-store');
-...
 ```
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a tiny library that mirrors IndexedDB, but replaces the weird `IDBReques
 
 ## Usage
 
-You can find `indexeddb-promised` as `idb` in npm. With Browserify or Webpack with Babel:
+You can find `indexeddb-promised` as `idb` in npm. With Browserify or Webpack and Babel:
 
 ```sh
 npm install --save idb


### PR DESCRIPTION
I found confusing that there is a package named `indexeddb-promised` in npm and lost a little bit of time trying to understand what was going on. This pr clarifies that in the README