### PR TITLE
Correct Typings for ObjectStore add and put.

### DIFF
--- a/lib/idb.d.ts
+++ b/lib/idb.d.ts
@@ -43,8 +43,8 @@ export interface ObjectStore {
   readonly indexNames: DOMStringList
   readonly autoIncrement: boolean
 
-  put(value: any, key?: IDBKeyRange | IDBValidKey): Promise<void>
-  add(value: any, key?: IDBKeyRange | IDBValidKey): Promise<void>
+  put(value: any, key?: IDBKeyRange | IDBValidKey): Promise<IDBValidKey>
+  add(value: any, key?: IDBKeyRange | IDBValidKey): Promise<IDBValidKey>
   delete(key: IDBKeyRange | IDBValidKey): Promise<void>
   clear(): Promise<void>
   get(key: any): Promise<any>


### PR DESCRIPTION
In my haste to put up a PR last night, I forgot to push a change I had sitting on my machine.  This PR fixes the typings for `ObjectStore.add()` and `ObjectStore.put()` return values.  They should return promises that resolve to keys, not nothing.

Thanks and sorry for the noise!