### PR TITLE
Reject a transaction promise when the transaction aborts

### DIFF
--- a/lib/idb.js
+++ b/lib/idb.js
@@ -178,6 +178,9 @@
       idbTransaction.onerror = function() {
         reject(idbTransaction.error);
       };
+      idbTransaction.onabort = function() {
+        reject(idbTransaction.error);
+      };
     });
   }
 


### PR DESCRIPTION
Transactions can be aborted when the page's quota is exceeded or other errors occur.
https://w3c.github.io/IndexedDB/#ref-for-request-6