### PR TITLE
Isomorphic imports 2

### DIFF
--- a/lib/idb.js
+++ b/lib/idb.js
@@ -27,7 +27,7 @@
     p.request = request;
     return p;
   }
-  
+
   function promisifyCursorRequestCall(obj, method, args) {
     var p = promisifyRequestCall(obj, method, args);
     return p.then(function(value) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -1,5 +1,5 @@
 module.exports = {
-  idb () {
-    return null;
+  idb: function () {
+    return undefined;
   }
 };

--- a/lib/node.js
+++ b/lib/node.js
@@ -1,0 +1,5 @@
+module.exports = {
+  idb () {
+    return null;
+  }
+};

--- a/lib/node.js
+++ b/lib/node.js
@@ -1,5 +1,10 @@
 module.exports = {
-  idb: function () {
-    return undefined;
+  idb: {
+    open: function () {
+      return Promise.reject('Idb requires a browser environment')
+    },
+    delete: function () {
+      return Promise.reject('Idb requires a browser environment')
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "idb",
   "version": "1.3.2",
   "description": "IndexedDB but with promises",
-  "main": "lib/idb.js",
+  "main": "lib/node.js",
+  "browser": "lib/idb.js",
   "typings": "lib/idb.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
specify main and browser fields in package.json

https://github.com/defunctzombie/package-browser-field-spec/blob/master/README.md 

main exports function that returns undefined
browser exports idb

alternative to this pull request: https://github.com/jakearchibald/idb/pull/18
and fixes this issue: https://github.com/jakearchibald/idb/issues/17

You can test in this project:
https://github.com/noahehall/react-f-your-starterkit

$ npm install
$ npm run dev > test on 127.0.0.1:3000
$ npm run prod > test on https://localhost:3000
