### PR TITLE
Added parent DB to the transaction

### DIFF
--- a/lib/idb.d.ts
+++ b/lib/idb.d.ts
@@ -80,6 +80,9 @@ export interface Transaction {
     /** The mode for isolating access to data in the object stores that are in the scope of the transaction. For possible values, see the Constants section below. The default value is readonly. */
     readonly mode: 'readonly' | 'readwrite' | 'versionchange';
 
+    /** The database connection with which this transaction is associated. */
+    readonly db: DB;
+
     /** Rolls back all the changes to objects in the database associated with this transaction. If this transaction has been aborted or completed, then this method throws an error event. */
     abort(): void;
 

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -187,7 +187,8 @@
 
   proxyProperties(Transaction, '_tx', [
     'objectStoreNames',
-    'mode'
+    'mode',
+    'db'
   ]);
 
   proxyMethods(Transaction, '_tx', IDBTransaction, [


### PR DESCRIPTION
If you have an open transaction you may also need the DB it belongs to - you can pass this as an additional variable but `IDBTransaction` already has a reference to it that `Transaction` doesn't.

I've just added this to the collection added by `proxyProperties` (which is enough for my purposes as I just need access to `tran.db.objectStoreNames`) but that's the underlying `IDBDatabase` rather than the wrapper object, so I think this may require further work to fully implement.