### PR TITLE
Fix problem with typescript default import

### DIFF
--- a/lib/idb.js
+++ b/lib/idb.js
@@ -303,6 +303,7 @@
 
   if (typeof module !== 'undefined') {
     module.exports = exp;
+    module.exports.default = module.exports;
   }
   else {
     self.idb = exp;


### PR DESCRIPTION
Hi,

I run into problem when using your library with typescript and then compiling it and bundling using browserify as your typing declares a default export which is not present in your library and thus I am getting undefined errors on runtime. This single line fixed it.