### PR TITLE
Cursor errors

### DIFF
--- a/lib/idb.js
+++ b/lib/idb.js
@@ -244,7 +244,7 @@
   // TODO: remove this once browsers do the right thing with promises
   ['openCursor', 'openKeyCursor'].forEach(function(funcName) {
 		const iterFuncName = funcName.replace('open', 'iterate')
-    function iterifyFunc(Constructor) {
+    function iterify(Constructor) {
       Constructor.prototype[iterFuncName] = function() {
         var args = toArray(arguments);
         var callback = args[args.length - 1];
@@ -255,7 +255,8 @@
         };
       };
     }
-		[ObjectStore, Index].forEach(iterifyFunc);
+		iterify(ObjectStore)
+		iterify(Index)
   });
 
   // polyfill getAll

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -246,7 +246,29 @@
 		const iterFuncName = funcName.replace('open', 'iterate')
     function iterify(Constructor, nativeName) {
       Constructor.prototype[iterFuncName] = function() {
+				/*
+					The provided iterator should be synchronous
+					(i.e. not yield promises)
+					because transactions go bad on idle cursors.
+					A cursor MUST continue BEFORE returning from onsuccess.
+					Return a promise from onsuccess, and the transaction WILL close.
+					This is why it's a bad idea to totally reimplement promises
+					because your database is a special snowflake.
+				*/
         var iter = arguments[arguments.length - 1];
+				if(!iter.next) {
+					// let's assume we were passed a callback on (value, key) arguments
+					const callback = iter;
+					iter = {
+						next: (cursor) => {
+							let res = callback(cursor.value, cursor.key);
+							if(res !== undefined) {
+								return {done: true, value: res};
+							}
+							return {done: false};
+						throw: function() {}
+					}
+				}
 				var args = Array.slice(arguments, 0, -1);
 
         var nativeObject = this[nativeName];
@@ -256,13 +278,15 @@
 						args);
 					request.onsuccess = function() {
 						var cursor = request.result;
-						// Note: iterator should return non-undefined
-						// if they need to differentiate between the iterator finishing
-						// and the cursor getting exhausted
+						/*
+							Note, iterator should return non-undefined
+							if you need to differentiate between the iterator finishing
+							and the cursor getting exhausted.
+						*/
 						if(!cursor) return resolve();
 						var res;
 						try {
-							res = iter.next(cursor.value);
+							res = iter.next(cursor);
 						} catch(e) {
 							return reject(e);
 						}
@@ -272,7 +296,10 @@
 					request.onerror = function() {
 						let e = request.result.error
 						reject(e);
-						iter.throw(e);
+						// all errors will stop the cursor anyway,
+						// so you SHOULD just catch the promise
+						// but eh
+						if(iter.throw) iter.throw(e);
 					};
       };
     }

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -266,7 +266,7 @@
 								return {done: true, value: res};
 							}
 							return {done: false};
-						throw: function() {}
+						}
 					}
 				}
 				var args = Array.slice(arguments, 0, -1);
@@ -301,8 +301,9 @@
 						// but eh
 						if(iter.throw) iter.throw(e);
 					};
-      };
-    }
+				});
+			}
+		}
 		iterify(ObjectStore, '_store')
 		iterify(Index, '_index')
   });

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -243,8 +243,9 @@
   // Add cursor iterators
   // TODO: remove this once browsers do the right thing with promises
   ['openCursor', 'openKeyCursor'].forEach(function(funcName) {
+		const iterFuncName = funcName.replace('open', 'iterate')
     [ObjectStore, Index].forEach(function(Constructor) {
-      Constructor.prototype[funcName.replace('open', 'iterate')] = function() {
+      Constructor.prototype[iterFuncName] = function() {
         var args = toArray(arguments);
         var callback = args[args.length - 1];
         var nativeObject = this._store || this._index;

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -244,19 +244,19 @@
   // TODO: remove this once browsers do the right thing with promises
   ['openCursor', 'openKeyCursor'].forEach(function(funcName) {
 		const iterFuncName = funcName.replace('open', 'iterate')
-    function iterify(Constructor) {
+    function iterify(Constructor, nativeName) {
       Constructor.prototype[iterFuncName] = function() {
         var args = toArray(arguments);
         var callback = args[args.length - 1];
-        var nativeObject = this._store || this._index;
+        var nativeObject = this[nativeName];
         var request = nativeObject[funcName].apply(nativeObject, args.slice(0, -1));
         request.onsuccess = function() {
           callback(request.result);
         };
       };
     }
-		iterify(ObjectStore)
-		iterify(Index)
+		iterify(ObjectStore, '_store')
+		iterify(Index, '_index')
   });
 
   // polyfill getAll

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -246,13 +246,34 @@
 		const iterFuncName = funcName.replace('open', 'iterate')
     function iterify(Constructor, nativeName) {
       Constructor.prototype[iterFuncName] = function() {
-        var args = toArray(arguments);
-        var callback = args[args.length - 1];
+        var iter = arguments[arguments.length - 1];
+				var args = Array.slice(arguments, 0, -1);
+
         var nativeObject = this[nativeName];
-        var request = nativeObject[funcName].apply(nativeObject, args.slice(0, -1));
-        request.onsuccess = function() {
-          callback(request.result);
-        };
+				return new Promise(function(resolve, reject) {
+					var request = nativeObject[funcName].apply(
+						nativeObject,
+						args);
+					request.onsuccess = function() {
+						var cursor = request.result;
+						// Note: iterator should return non-undefined
+						// if they need to differentiate between the iterator finishing
+						// and the cursor getting exhausted
+						if(!cursor) return resolve();
+						var res;
+						try {
+							res = iter.next(cursor.value);
+						} catch(e) {
+							return reject(e);
+						}
+						if(res.done) return resolve(res.value);
+						cursor.continue()
+					};
+					request.onerror = function() {
+						let e = request.result.error
+						reject(e);
+						iter.throw(e);
+					};
       };
     }
 		iterify(ObjectStore, '_store')

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -244,7 +244,7 @@
   // TODO: remove this once browsers do the right thing with promises
   ['openCursor', 'openKeyCursor'].forEach(function(funcName) {
 		const iterFuncName = funcName.replace('open', 'iterate')
-    [ObjectStore, Index].forEach(function(Constructor) {
+    function iterifyFunc(Constructor) {
       Constructor.prototype[iterFuncName] = function() {
         var args = toArray(arguments);
         var callback = args[args.length - 1];
@@ -254,7 +254,8 @@
           callback(request.result);
         };
       };
-    });
+    }
+		[ObjectStore, Index].forEach(iterifyFunc);
   });
 
   // polyfill getAll

--- a/test/idb.js
+++ b/test/idb.js
@@ -56,11 +56,16 @@ describe('idb interface', () => {
     const tx = db.transaction('list');
     const values = [];
 
-    tx.objectStore('list').iterateCursor(cursor => {
-      if (!cursor) return;
-      values.push(cursor.value);
-      cursor.continue();
-    });
+    tx.objectStore('list').iterateCursor((function*() {
+			try {
+				while((let value = yield)) {
+					values.push(value);
+				}
+			} catch(e) {
+				values.push("aaaaaaaaa")
+				console.error("there was an error",e);
+			}
+    })());
 
     await tx.complete;
     assert.equal(values.join(), 'a,b,c,d,e');

--- a/test/idb.js
+++ b/test/idb.js
@@ -56,7 +56,7 @@ describe('idb interface', () => {
     const tx = db.transaction('list');
     const values = [];
 
-    tx.objectStore('list').iterateCursor((function*() {
+    const cursordone = tx.objectStore('list').iterateCursor((function*() {
 			try {
 				while((let value = yield)) {
 					values.push(value);
@@ -67,7 +67,7 @@ describe('idb interface', () => {
 			}
     })());
 
-    await tx.complete;
+    await Promise.race([tx.complete, cursordone]);
     assert.equal(values.join(), 'a,b,c,d,e');
     db.close();
   });


### PR DESCRIPTION
Well, after spending an hour figuring out that I made a bad query and it silently ignored the error, I figured the iteration functions iterateCursor and iterateKeyCursor could do with some improvement. Specifically, they could handle cursor errors gracefully, and allow the callback to return a value, instead of requiring side effects and mutation to do that.

So... it isn't... exactly the same. But it's pretty easy to change to the new (value key) => undefined callback format, or use iterators if you need to do some weird manipulation of the cursor, even though the only allowed operations in a cursor request seem to be calling cursor.continue or ceasing iteration. Or ceasing iteration because of error. Maybe there's an operation I don't know about, that's totally useful!