### PR TITLE
Reject when 'open' or 'delete' blocks. Fixes #47.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ This method returns a promise that resolves to a `DB`.
 
 `upgradeCallback` is called if `version` is greater than the version last opened. It's similar to IDB's `onupgradeneeded`. The callback receives an instance of `UpgradeDB`.
 
+If the database is already in use (i.e. already open), the promise will reject with an error.
+
 ```js
 idb.open('keyval-store', 2, upgradeDB => {
   // Note: we don't use 'break' in this switch statement,
@@ -226,8 +228,15 @@ idb.open('keyval-store', 2, upgradeDB => {
 
 Behaves like `indexedDB.deleteDatabase`, but returns a promise.
 
+If the database is in use (i.e. still open), the promise will reject with an error. Once all related database connections are closed, IndexedDB will automatically delete the database.
+
 ```js
-idb.delete('keyval-store').then(() => console.log('done!'));
+idb.delete('keyval-store')
+  .then(() => console.log('done'))
+  .catch((err) => {
+    // Database is still in use; all connections to the database needs to close.
+    // Once the connections are closed, the database will be deleted automatically.
+  });
 ```
 
 ## `DB`

--- a/lib/idb.js
+++ b/lib/idb.js
@@ -286,23 +286,37 @@
 
   var exp = {
     open: function(name, version, upgradeCallback) {
-      var p = promisifyRequestCall(indexedDB, 'open', [name, version]);
-      var request = p.request;
-
-      if (request) {
-        request.onupgradeneeded = function(event) {
-          if (upgradeCallback) {
-            upgradeCallback(new UpgradeDB(request.result, event.oldVersion, request.transaction));
-          }
+      var request = indexedDB.open(name, version);
+      return new Promise(function(resolve, reject) {
+        request.oncomplete = function() {
+          resolve(new DB(request.result));
         };
-      }
-
-      return p.then(function(db) {
-        return new DB(db);
+        request.onerror = function() {
+          reject(request.error);
+        };
+        request.onblocked = function() {
+          reject(new Error('Database still in use'));
+        };
+        if (upgradeCallback) {
+          request.onupgradeneeded = function(event) {
+            upgradeCallback(new UpgradeDB(request.result, event.oldVersion, request.transaction));
+          };
+        }
       });
     },
     delete: function(name) {
-      return promisifyRequestCall(indexedDB, 'deleteDatabase', [name]);
+      var request = indexedDB.deleteDatabase(name);
+      return new Promise(function(resolve, reject) {
+        request.oncomplete = function() {
+          resolve();
+        };
+        request.onerror = function() {
+          reject(request.error);
+        };
+        request.onblocked = function() {
+          reject(new Error('Database still in use'));
+        };
+      });
     }
   };
 


### PR DESCRIPTION
This PR implements the first API option discussed in #47.

Previously, when a user tries to delete a database with an existing connection, the promise will not resolve or reject until the existing connection is closed. This caused some confusion for me, which prompted me to submit this change.

When a user tries to connect to a database that already has an open connection, `idb.open` will reject with an error. Likewise, when a user tries to delete a data that is in use, `idb.close` will reject with an error.

I am concerned that this would prompt a major version bump. Some users might be relying on `open` or `delete` to wait until existing connections are closed.