### PR TITLE
Fix: DOMException DataError Invalid Key on getAll

### DIFF
--- a/lib/idb.js
+++ b/lib/idb.js
@@ -265,6 +265,7 @@
     Constructor.prototype.getAll = function(query, count) {
       var instance = this;
       var items = [];
+      query = query !== undefined ? query : null;
 
       return new Promise(function(resolve) {
         instance.iterateCursor(query, function(cursor) {


### PR DESCRIPTION
Hey there,

I run into a problem when using it on a Ionic app on a Android 4.4 Kitkat device.

The getAll polyfill for an objectStore was taking "undefined" as a query and thus it was raising a DataError DOMException with InvalidKey. 

I fixed it by checking if query comes as undefined and setting it null if it does.
