### PR TITLE
Add AMD export

### DIFF
--- a/lib/idb.js
+++ b/lib/idb.js
@@ -309,8 +309,9 @@
   if (typeof module !== 'undefined') {
     module.exports = exp;
     module.exports.default = module.exports;
-  }
-  else {
+  } else if (typeof define === 'function' && define.amd) {
+    define(exp);
+  } else {
     self.idb = exp;
   }
 }());


### PR DESCRIPTION
Hi Jake! 👋 
We recently migrated from `idb-keyval` to `idb` at ReSpec (https://github.com/w3c/respec/pull/1964). Needing AMD support there until we move off requirejs.