### PR TITLE
Fix typo type error in TypeScript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ const db = await openDb<V2MyDB>('my-db', 2, {
 
       // We'll need to copy the data, that means casting the transaction too:
       const v1Tx = tx as unknown as IDBPTransaction<V1MyDB>;
-      let cursor = tx.objectStore('favourite-numbers').openCursor();
+      let cursor = await tx.objectStore('favourite-numbers').openCursor();
 
       while (cursor) {
         store.add(cursor.value, cursor.key);
@@ -219,4 +219,4 @@ const db = await openDb<V2MyDB>('my-db', 2, {
 });
 ```
 
-You can also cast to a typeless database/transaction by omiting the type, eg `db as unknown as IDBPDatabase`.
+You can also cast to a typeless database/transaction by omiting the type, eg `db as IDBPDatabase`.


### PR DESCRIPTION
`openCursor()` returns a promise so it needs to be `await`ed.

I also updated the cast example at the bottom since the generics can be changed to unknown with a single cast.

---

Slightly related:

In the sample opting out of types code, the technically more type-safe way would be to cast the database to an unknown DB then cast again to the desired type:
```typescript
let v1Db = db as IDBPDatabase<unknown> as IDBPDatabase<V1MyDB>;
v1Db = db as IDBPDatabase as IDBPDatabase<V1MyDB>; // also works
```
Personally I think its not needed since the database is cast again to the typed `IDBPDatabase` immediately. Just wanted to bring it to your attention 😄 