### PR TITLE
Change `objectStoreNames` to DOMStringList

### DIFF
--- a/lib/entry.ts
+++ b/lib/entry.ts
@@ -146,7 +146,6 @@ type IDBPDatabaseExtends = Omit<
 export interface TypedDOMStringList<
   T extends string
 > extends DOMStringList {
-    readonly length: number;
     contains(string: T): boolean;
     item(index: number): T | null;
     [index: number]: T;

--- a/lib/entry.ts
+++ b/lib/entry.ts
@@ -140,13 +140,26 @@ type IDBPDatabaseExtends = Omit<
   'createObjectStore' | 'deleteObjectStore' | 'transaction' | 'objectStoreNames'
 >;
 
+/**
+ * A variation of DOMStringList with precise string types
+ */
+export interface TypedDOMStringList<
+  T extends string
+> extends DOMStringList {
+    readonly length: number;
+    contains(string: T): boolean;
+    item(index: number): T | null;
+    [index: number]: T;
+    [Symbol.iterator](): IterableIterator<T>;
+}
+
 export interface IDBPDatabase<
   DBTypes extends DBSchema | unknown = unknown,
 > extends IDBPDatabaseExtends {
   /**
    * The names of stores in the database.
    */
-  readonly objectStoreNames: StoreNames<DBTypes>[];
+  readonly objectStoreNames: TypedDOMStringList<StoreNames<DBTypes>>;
   /**
    * Creates a new object store.
    *

--- a/test/main.ts
+++ b/test/main.ts
@@ -9,6 +9,7 @@ import {
   IDBPCursorWithValue,
   IDBPCursor,
   IDBPIndex,
+  TypedDOMStringList,
 } from '../lib/';
 import { assert as typeAssert, IsExact } from 'conditional-type-checks';
 import {
@@ -29,12 +30,12 @@ suite('IDBPDatabase', () => {
 
     typeAssert<IsExact<
       typeof schemaDB.objectStoreNames,
-      ('key-val-store' | 'object-store')[]
+      TypedDOMStringList<'key-val-store' | 'object-store'>
     >>(true);
 
     typeAssert<IsExact<
       typeof db.objectStoreNames,
-      string[]
+      DOMStringList
     >>(true);
   });
 


### PR DESCRIPTION
Add typed version of `DOMStringList` and use it as the type for `objectStoreNames`.

Fixes #101