### PR TITLE
Add npm "test" script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,6 +1774,12 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "mime": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -2088,6 +2094,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "opener": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+      "dev": true
     },
     "os-locale": {
       "version": "3.1.0",
@@ -2452,6 +2464,16 @@
             "path-parse": "^1.0.6"
           }
         }
+      }
+    },
+    "rollup-plugin-serve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-serve/-/rollup-plugin-serve-1.0.1.tgz",
+      "integrity": "sha512-bni0pb4s1YLvn1xBmj+dH1OsLdp8gWA4zqh3yuEtT6/YHhg3nDneGU2GwMcRDQwY2tXzuI0uSeAlF1rY+ODitg==",
+      "dev": true,
+      "requires": {
+        "mime": ">=2.0.3",
+        "opener": "1"
       }
     },
     "rollup-plugin-terser": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "clean": "rm -rf build test-build",
     "build": "npm run clean && rollup -c && gzip-size build/iife/index-min.js && gzip-size build/iife/with-async-ittr-min.js",
-    "dev": "npm run clean && rollup -c --watch"
+    "dev": "npm run clean && rollup -c --watch",
+    "test": "npm run clean && rollup -c test/rollup.config.js"
   },
   "repository": {
     "type": "git",
@@ -27,6 +28,7 @@
     "rollup-plugin-commonjs": "^9.2.1",
     "rollup-plugin-copy": "^0.2.3",
     "rollup-plugin-node-resolve": "^4.0.1",
+    "rollup-plugin-serve": "^1.0.1",
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript2": "^0.20.1",
     "tslint": "^5.14.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,31 +1,5 @@
 import typescript from 'rollup-plugin-typescript2';
 import { terser } from 'rollup-plugin-terser';
-import copy from 'rollup-plugin-copy';
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
-
-const testBuild = {
-  plugins: [
-    resolve(),
-    commonjs({
-      namedExports: {
-        'chai': ['assert'],
-      },
-    }),
-    typescript({
-      tsconfig: 'test/tsconfig.json',
-      useTsconfigDeclarationDir: true
-    }),
-    copy({
-      'test/index.html': 'test-build/index.html',
-    }),
-  ],
-  input: ['test/index.ts', 'test/main.ts', 'test/open.ts', 'test/iterate.ts'],
-  output: {
-    dir: 'test-build',
-    format: 'esm'
-  },
-};
 
 const esm = {
   plugins: [typescript({ useTsconfigDeclarationDir: true })],
@@ -72,5 +46,5 @@ const iffeIttrMin = {
 };
 
 export default [
-  testBuild, esm, iffeMin, iffeIttrMin,
+  esm, iffeMin, iffeIttrMin,
 ];

--- a/test/rollup.config.js
+++ b/test/rollup.config.js
@@ -1,0 +1,33 @@
+import typescript from 'rollup-plugin-typescript2';
+import copy from 'rollup-plugin-copy';
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import serve from 'rollup-plugin-serve';
+
+export default {
+  plugins: [
+    resolve(),
+    commonjs({
+      namedExports: {
+        'chai': ['assert'],
+      },
+    }),
+    typescript({
+      tsconfig: 'test/tsconfig.json',
+      useTsconfigDeclarationDir: true
+    }),
+    copy({
+      'test/index.html': 'test-build/index.html',
+    }),
+    serve({
+      open: true,
+      openPage: '/test-build/index.html',
+      contentBase: './',
+    }),
+  ],
+  input: ['test/index.ts', 'test/main.ts', 'test/open.ts', 'test/iterate.ts'],
+  output: {
+    dir: 'test-build',
+    format: 'esm'
+  },
+}


### PR DESCRIPTION
This PR addresses issue #109.
Using `npm test` is a standard for testing packages. Still, it may be a good idea to document it somewhere, like in the CONTRIBUTING file.
Also, tests aren't built when building the library itself anymore.