### PR TITLE
README: deleteDB missing params

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,15 @@ const db = await openDB(name, version, {
 Deletes a database.
 
 ```js
-await deleteDB(name);
+await deleteDB(name, {
+  blocked() {
+    // …
+  }
+});
 ```
 
 * `name`: Name of the database.
+* `blocked` (optional): Called if the database already exists and there are open connections that don’t close in response to a versionchange event, the request will be blocked until all they close.
 
 ## `unwrap`
 


### PR DESCRIPTION
`deleteDB` accepts `blocked` callback
https://github.com/jakearchibald/idb/blob/master/lib/entry.ts#L73
`blocked` description is from the spec
https://www.w3.org/TR/IndexedDB/#factory-interface