### PR TITLE
Return void instead of undefined

### DIFF
--- a/build/esm/entry.d.ts
+++ b/build/esm/entry.d.ts
@@ -151,7 +151,7 @@ export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown> exte
      *
      * @param storeName Name of the store.
      */
-    clear(name: StoreNames<DBTypes>): Promise<undefined>;
+    clear(name: StoreNames<DBTypes>): Promise<void>;
     /**
      * Retrieves the number of records matching the given query in a store.
      *
@@ -182,7 +182,7 @@ export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown> exte
      * @param storeName Name of the store.
      * @param key
      */
-    delete<Name extends StoreNames<DBTypes>>(storeName: Name, key: StoreKey<DBTypes, Name> | IDBKeyRange): Promise<undefined>;
+    delete<Name extends StoreNames<DBTypes>>(storeName: Name, key: StoreKey<DBTypes, Name> | IDBKeyRange): Promise<void>;
     /**
      * Retrieves the value of the first record in a store matching the query.
      *
@@ -306,7 +306,7 @@ export interface IDBPTransaction<DBTypes extends DBSchema | unknown = unknown, T
     /**
      * Promise for the completion of this transaction.
      */
-    readonly done: Promise<undefined>;
+    readonly done: Promise<void>;
     /**
      * The associated object store, if the transaction covers a single store, otherwise undefined.
      */
@@ -339,7 +339,7 @@ export interface IDBPObjectStore<DBTypes extends DBSchema | unknown = unknown, T
     /**
      * Deletes all records in store.
      */
-    clear(): Promise<undefined>;
+    clear(): Promise<void>;
     /**
      * Retrieves the number of records matching the given query.
      */
@@ -353,7 +353,7 @@ export interface IDBPObjectStore<DBTypes extends DBSchema | unknown = unknown, T
     /**
      * Deletes records in store matching the given query.
      */
-    delete(key: StoreKey<DBTypes, StoreName> | IDBKeyRange): Promise<undefined>;
+    delete(key: StoreKey<DBTypes, StoreName> | IDBKeyRange): Promise<void>;
     /**
      * Retrieves the value of the first record matching the query.
      *
@@ -530,7 +530,7 @@ export interface IDBPCursor<DBTypes extends DBSchema | unknown = unknown, TxStor
     /**
      * Delete the current record.
      */
-    delete(): Promise<undefined>;
+    delete(): Promise<void>;
     /**
      * Updated the current record.
      */

--- a/lib/entry.ts
+++ b/lib/entry.ts
@@ -262,7 +262,7 @@ export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown>
    *
    * @param storeName Name of the store.
    */
-  clear(name: StoreNames<DBTypes>): Promise<undefined>;
+  clear(name: StoreNames<DBTypes>): Promise<void>;
   /**
    * Retrieves the number of records matching the given query in a store.
    *
@@ -306,7 +306,7 @@ export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown>
   delete<Name extends StoreNames<DBTypes>>(
     storeName: Name,
     key: StoreKey<DBTypes, Name> | IDBKeyRange,
-  ): Promise<undefined>;
+  ): Promise<void>;
   /**
    * Retrieves the value of the first record in a store matching the query.
    *
@@ -486,7 +486,7 @@ export interface IDBPTransaction<
   /**
    * Promise for the completion of this transaction.
    */
-  readonly done: Promise<undefined>;
+  readonly done: Promise<void>;
   /**
    * The associated object store, if the transaction covers a single store, otherwise undefined.
    */
@@ -550,7 +550,7 @@ export interface IDBPObjectStore<
   /**
    * Deletes all records in store.
    */
-  clear(): Promise<undefined>;
+  clear(): Promise<void>;
   /**
    * Retrieves the number of records matching the given query.
    */
@@ -568,7 +568,7 @@ export interface IDBPObjectStore<
   /**
    * Deletes records in store matching the given query.
    */
-  delete(key: StoreKey<DBTypes, StoreName> | IDBKeyRange): Promise<undefined>;
+  delete(key: StoreKey<DBTypes, StoreName> | IDBKeyRange): Promise<void>;
   /**
    * Retrieves the value of the first record matching the query.
    *
@@ -848,7 +848,7 @@ export interface IDBPCursor<
   /**
    * Delete the current record.
    */
-  delete(): Promise<undefined>;
+  delete(): Promise<void>;
   /**
    * Updated the current record.
    */


### PR DESCRIPTION
If the return value will be ignored, `void` is preferred to `undefined`.