### PR TITLE
fix: null error

### DIFF
--- a/lib/wrap-idb-value.ts
+++ b/lib/wrap-idb-value.ts
@@ -104,8 +104,8 @@ function cacheDonePromiseForTransaction(tx: IDBTransaction): void {
       resolve();
       unlisten();
     };
-    const error = () => {
-      reject(tx.error);
+    const error = (e) => {
+      reject(tx.error || e.target.error || e.srcElement.error);
       unlisten();
     };
     tx.addEventListener('complete', complete);


### PR DESCRIPTION
When adding a duplicate key the tx.error was null but `tx.srcElement.error` wasn't

This PR reads it from there if it fails there instead

A long-term solution would be to check for srcElement/target .onerror as well as tx.onerror