### PR TITLE
add with-async-ittr-cjs.d.ts

### DIFF
--- a/with-async-ittr-cjs.d.ts
+++ b/with-async-ittr-cjs.d.ts
@@ -1,0 +1,1 @@
+export * from './lib';


### PR DESCRIPTION
fixes #136 by adding a file `with-async-ittr-cjs.d.ts`, so that I can import from `idb/with-async-ittr-cjs` with impunity. 