### PR TITLE
Add mode to IDBPTransaction

### DIFF
--- a/src/database-extras.ts
+++ b/src/database-extras.ts
@@ -1,6 +1,6 @@
 import { Func } from './util';
 import { replaceTraps } from './wrap-idb-value';
-import { IDBPDatabase, IDBPObjectStore, IDBPIndex } from './entry';
+import { IDBPDatabase, IDBPIndex } from './entry';
 
 const readMethods = ['get', 'getKey', 'getAll', 'getAllKeys', 'count'];
 const writeMethods = ['put', 'add', 'delete', 'clear'];
@@ -41,7 +41,10 @@ function getMethod(
   ) {
     // isWrite ? 'readwrite' : undefined gzipps better, but fails in Edge :(
     const tx = this.transaction(storeName, isWrite ? 'readwrite' : 'readonly');
-    let target: IDBPObjectStore | IDBPIndex = tx.store;
+    let target:
+      | typeof tx.store
+      | IDBPIndex<unknown, string[], string, string, 'readwrite' | 'readonly'> =
+      tx.store;
     if (useIndex) target = target.index(args.shift());
     const returnVal = await (target as any)[targetFuncName](...args);
     if (isWrite) await tx.done;

--- a/src/wrap-idb-value.ts
+++ b/src/wrap-idb-value.ts
@@ -256,12 +256,12 @@ export function wrap(value: any): any {
  * @param value The enhanced object to revert.
  */
 interface Unwrap {
-  (value: IDBPCursorWithValue<any, any, any, any>): IDBCursorWithValue;
-  (value: IDBPCursor<any, any, any, any>): IDBCursor;
+  (value: IDBPCursorWithValue<any, any, any, any, any>): IDBCursorWithValue;
+  (value: IDBPCursor<any, any, any, any, any>): IDBCursor;
   (value: IDBPDatabase): IDBDatabase;
   (value: IDBPIndex<any, any, any, any>): IDBIndex;
   (value: IDBPObjectStore<any, any, any>): IDBObjectStore;
-  (value: IDBPTransaction<any, any>): IDBTransaction;
+  (value: IDBPTransaction<any, any, any>): IDBTransaction;
   <T extends any>(value: Promise<IDBPDatabase<T>>): IDBOpenDBRequest;
   (value: Promise<IDBPDatabase>): IDBOpenDBRequest;
   <T>(value: Promise<T>): IDBRequest<T>;

--- a/test/open.ts
+++ b/test/open.ts
@@ -32,7 +32,16 @@ suite('openDb', () => {
         assert.strictEqual(oldVersion, 0);
         assert.strictEqual(newVersion, version);
 
-        typeAssert<IsExact<typeof tx, IDBPTransaction<TestDBSchema>>>(true);
+        typeAssert<
+          IsExact<
+            typeof tx,
+            IDBPTransaction<
+              TestDBSchema,
+              ('key-val-store' | 'object-store')[],
+              'versionchange'
+            >
+          >
+        >(true);
         assert.instanceOf(tx, IDBTransaction, 'db instance');
         assert.strictEqual(tx.mode, 'versionchange', 'tx mode');
       },
@@ -93,7 +102,12 @@ suite('openDb', () => {
       upgrade(db, oldVersion, newVersion, tx) {
         upgradeRun = true;
         typeAssert<IsExact<typeof db, IDBPDatabase>>(true);
-        typeAssert<IsExact<typeof tx, IDBPTransaction>>(true);
+        typeAssert<
+          IsExact<
+            typeof tx,
+            IDBPTransaction<unknown, string[], 'versionchange'>
+          >
+        >(true);
       },
     });
 


### PR DESCRIPTION
Fixes https://github.com/jakearchibald/idb/issues/140

1. Add type check for transaction's mode, it is impossible to pass a `readonly` transaction to a function that requires a `readwrite` transaction.

2. Exclude `add()`, `put()`, `delete()`, `clear()` from `objectstore` created by `readonly` transaction. Keep `createIndex()` only in `objectstore` created by `versionchange` transaction.

```ts
const schemaDB = await openDBWithSchema();
const db = schemaDB as IDBPDatabase<TestDBSchema>;

const t1 = db.transaction("store1", "readonly") 
const t2 = db.transaction("store1", "readwrite") 

const action = (t: IDBPTransaction<TestDBSchema, ['store1'], "readwrite">) => {
  t.store.clear()
}

// ts compiler: Type '"readonly"' is not assignable to type '"readwrite"'
action(t1)
// ts compiler: IDBPObjectStore<TestDBSchema, ["store1"], "store1", "readonly">.add: undefined
t1.store.add({name: 'm'})
// ts compiler: IDBPObjectStore<TestDBSchema, ["store1"], "store1", "readwrite">.createIndex: undefined
t2.store.createIndex('name', 'name')
```