### PR TITLE
Change the typing of IDBPDatabase.transaction

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -243,6 +243,7 @@ export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown>
    *
    * @param storeNames The object store(s) this transaction needs.
    * @param mode
+   * @param options Dictionary of other options.
    */
   transaction<Name extends StoreNames<DBTypes>>(
     storeNames: Name,

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -208,6 +208,10 @@ export interface TypedDOMStringList<T extends string> extends DOMStringList {
   [Symbol.iterator](): IterableIterator<T>;
 }
 
+interface IDBTransactionOptions {
+  durability?: 'default'|'strict'|'relaxed';
+}
+
 export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown>
   extends IDBPDatabaseExtends {
   /**
@@ -238,10 +242,12 @@ export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown>
   transaction<Name extends StoreNames<DBTypes>>(
     storeNames: Name,
     mode?: IDBTransactionMode,
+    options?: IDBTransactionOptions,
   ): IDBPTransaction<DBTypes, [Name]>;
   transaction<Names extends StoreNames<DBTypes>[]>(
     storeNames: Names,
     mode?: IDBTransactionMode,
+    options?: IDBTransactionOptions,
   ): IDBPTransaction<DBTypes, Names>;
 
   // Shortcut methods

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -209,7 +209,12 @@ export interface TypedDOMStringList<T extends string> extends DOMStringList {
 }
 
 interface IDBTransactionOptions {
-  durability?: 'default'|'strict'|'relaxed';
+  /**
+   * The durability of the transaction.
+   *
+   * The default is "default". Using "relaxed" provides better performance, but with fewer guarantees. Web applications are encouraged to use "relaxed" for ephemeral data such as caches or quickly changing records, and "strict" in cases where reducing the risk of data loss outweighs the impact to performance and power.
+  */
+  durability?: 'default' | 'strict' | 'relaxed';
 }
 
 export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown>


### PR DESCRIPTION
Change the typing of IDBPDatabase.transaction to allow the optional "options" parameter. See https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/transaction.

Fixes #203 