### PR TITLE
fix(ts): `moduleResolution: node12` compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "types": "./build/index.d.ts",
   "exports": {
     ".": {
+      "types": "./build/index.d.ts",
       "module": "./build/index.js",
       "import": "./build/index.js",
       "default": "./build/index.cjs"
     },
     "./with-async-ittr": {
+      "types": "./with-async-ittr.d.ts",
       "module": "./with-async-ittr.js",
       "import": "./with-async-ittr.js",
       "default": "./with-async-ittr.cjs"

--- a/src/async-iterators.ts
+++ b/src/async-iterators.ts
@@ -1,6 +1,6 @@
-import { instanceOfAny, Func } from './util';
-import { replaceTraps, reverseTransformCache, unwrap } from './wrap-idb-value';
-import { IDBPObjectStore, IDBPIndex, IDBPCursor } from './entry';
+import { instanceOfAny, Func } from './util.js';
+import { replaceTraps, reverseTransformCache, unwrap } from './wrap-idb-value.js';
+import { IDBPObjectStore, IDBPIndex, IDBPCursor } from './entry.js';
 
 const advanceMethodProps = ['continue', 'continuePrimaryKey', 'advance'];
 const methodMap: { [s: string]: Func } = {};

--- a/src/database-extras.ts
+++ b/src/database-extras.ts
@@ -1,6 +1,6 @@
-import { Func } from './util';
-import { replaceTraps } from './wrap-idb-value';
-import { IDBPDatabase, IDBPIndex } from './entry';
+import { Func } from './util.js';
+import { replaceTraps } from './wrap-idb-value.js';
+import { IDBPDatabase, IDBPIndex } from './entry.js';
 
 const readMethods = ['get', 'getKey', 'getAll', 'getAllKeys', 'count'];
 const writeMethods = ['put', 'add', 'delete', 'clear'];

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,4 +1,4 @@
-import { wrap } from './wrap-idb-value';
+import { wrap } from './wrap-idb-value.js';
 
 export interface OpenDBCallbacks<DBTypes extends DBSchema | unknown> {
   /**
@@ -100,7 +100,7 @@ export function deleteDB(
   return wrap(request).then(() => undefined);
 }
 
-export { unwrap, wrap } from './wrap-idb-value';
+export { unwrap, wrap } from './wrap-idb-value.js';
 
 // === The rest of this file is type defs ===
 type KeyToKeyNoIndex<T> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from './entry';
-import './database-extras';
+export * from './entry.js';
+import './database-extras.js';

--- a/src/wrap-idb-value.ts
+++ b/src/wrap-idb-value.ts
@@ -5,8 +5,8 @@ import {
   IDBPIndex,
   IDBPObjectStore,
   IDBPTransaction,
-} from './entry';
-import { Constructor, Func, instanceOfAny } from './util';
+} from './entry.js';
+import { Constructor, Func, instanceOfAny } from './util.js';
 
 let idbProxyableTypes: Constructor[];
 let cursorAdvanceMethods: Func[];


### PR DESCRIPTION
TypeScript needs `types` condition when `pkg.exports` is defined 

<img width="503" alt="image" src="https://user-images.githubusercontent.com/1925840/166841471-7006a616-ea0f-4392-b022-ebb363e32485.png">

Source: https://github.com/microsoft/TypeScript/issues/33079#issuecomment-950214842