### PR TITLE
Narrow types when an object store is declared as a union

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -682,10 +682,12 @@ export interface IDBPObjectStore<
    */
   add: Mode extends 'readonly'
     ? undefined
-    : (
-        value: StoreValue<DBTypes, StoreName>,
-        key?: StoreKey<DBTypes, StoreName> | IDBKeyRange,
-      ) => Promise<StoreKey<DBTypes, StoreName>>;
+    : <Value extends StoreValue<DBTypes, StoreName>>(
+        value: Value,
+        key?: StoreKeyFromValue<DBTypes, StoreName, Value>,
+        // Somehow the return type is different from the key parameter type. Not
+        // sure how to fix it. The IDBPDatabase equivalent is fine.
+      ) => Promise<StoreKeyFromValue<DBTypes, StoreName, Value>>;
   /**
    * Deletes all records in store.
    */
@@ -719,37 +721,37 @@ export interface IDBPObjectStore<
    *
    * Resolves with undefined if no match is found.
    */
-  get(
-    query: StoreKey<DBTypes, StoreName> | IDBKeyRange,
-  ): Promise<StoreValue<DBTypes, StoreName> | undefined>;
+  get<Key extends StoreKey<DBTypes, StoreName> | IDBKeyRange>(
+    query: Key,
+  ): Promise<StoreValue<DBTypes, StoreName, Key> | undefined>;
   /**
    * Retrieves all values that match the query.
    *
    * @param query
    * @param count Maximum number of values to return.
    */
-  getAll(
-    query?: StoreKey<DBTypes, StoreName> | IDBKeyRange | null,
+  getAll<Key extends StoreKey<DBTypes, StoreName> | IDBKeyRange | null>(
+    query?: Key,
     count?: number,
-  ): Promise<StoreValue<DBTypes, StoreName>[]>;
+  ): Promise<StoreValue<DBTypes, StoreName, Key>[]>;
   /**
    * Retrieves the keys of records matching the query.
    *
    * @param query
    * @param count Maximum number of keys to return.
    */
-  getAllKeys(
-    query?: StoreKey<DBTypes, StoreName> | IDBKeyRange | null,
+  getAllKeys<Key extends StoreKey<DBTypes, StoreName> | IDBKeyRange | null>(
+    query?: Key,
     count?: number,
-  ): Promise<StoreKey<DBTypes, StoreName>[]>;
+  ): Promise<StoreKey<DBTypes, StoreName, Key>[]>;
   /**
    * Retrieves the key of the first record that matches the query.
    *
    * Resolves with undefined if no match is found.
    */
-  getKey(
-    query: StoreKey<DBTypes, StoreName> | IDBKeyRange,
-  ): Promise<StoreKey<DBTypes, StoreName> | undefined>;
+  getKey<Key extends StoreKey<DBTypes, StoreName> | IDBKeyRange>(
+    query: Key,
+  ): Promise<StoreKey<DBTypes, StoreName, Key> | undefined>;
   /**
    * Get a query of a given name.
    */
@@ -793,10 +795,11 @@ export interface IDBPObjectStore<
    */
   put: Mode extends 'readonly'
     ? undefined
-    : (
-        value: StoreValue<DBTypes, StoreName>,
-        key?: StoreKey<DBTypes, StoreName> | IDBKeyRange,
-      ) => Promise<StoreKey<DBTypes, StoreName>>;
+    : <Value extends StoreValue<DBTypes, StoreName>>(
+        value: Value,
+        key?: StoreKeyFromValue<DBTypes, StoreName, Value>,
+        // ditto the add method
+      ) => Promise<StoreKeyFromValue<DBTypes, StoreName, Value>>;
   /**
    * Iterate over the store.
    */

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -682,12 +682,13 @@ export interface IDBPObjectStore<
    */
   add: Mode extends 'readonly'
     ? undefined
-    : <Value extends StoreValue<DBTypes, StoreName>>(
+    : <
+        Value extends StoreValue<DBTypes, Name>,
+        Name extends StoreName = StoreName,
+      >(
         value: Value,
-        key?: StoreKeyFromValue<DBTypes, StoreName, Value>,
-        // Somehow the return type is different from the key parameter type. Not
-        // sure how to fix it. The IDBPDatabase equivalent is fine.
-      ) => Promise<StoreKeyFromValue<DBTypes, StoreName, Value>>;
+        key?: StoreKeyFromValue<DBTypes, Name, Value>,
+      ) => Promise<StoreKeyFromValue<DBTypes, Name, Value>>;
   /**
    * Deletes all records in store.
    */
@@ -795,11 +796,13 @@ export interface IDBPObjectStore<
    */
   put: Mode extends 'readonly'
     ? undefined
-    : <Value extends StoreValue<DBTypes, StoreName>>(
+    : <
+        Value extends StoreValue<DBTypes, Name>,
+        Name extends StoreName = StoreName,
+      >(
         value: Value,
-        key?: StoreKeyFromValue<DBTypes, StoreName, Value>,
-        // ditto the add method
-      ) => Promise<StoreKeyFromValue<DBTypes, StoreName, Value>>;
+        key?: StoreKeyFromValue<DBTypes, Name, Value>,
+      ) => Promise<StoreKeyFromValue<DBTypes, Name, Value>>;
   /**
    * Iterate over the store.
    */

--- a/test/main.ts
+++ b/test/main.ts
@@ -541,6 +541,20 @@ suite('IDBPDatabase', () => {
     }
 
     {
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.put<'union-store', 'five'>>[1],
+          'five'
+        >
+      >(true);
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.put<'union-store', 'five'>>[2],
+          5 | undefined
+        >
+      >(true);
+
       const key = await schemaDB.put('union-store', 'five', 5);
 
       typeAssert<IsExact<typeof key, 5>>(true);
@@ -607,6 +621,20 @@ suite('IDBPDatabase', () => {
     }
 
     {
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.add<'union-store', 'five'>>[1],
+          'five'
+        >
+      >(true);
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.add<'union-store', 'five'>>[2],
+          5 | undefined
+        >
+      >(true);
+
       const key = await schemaDB.add('union-store', 'five', 5);
 
       typeAssert<IsExact<typeof key, 5>>(true);
@@ -1152,15 +1180,15 @@ suite('IDBPObjectStore', () => {
 
       typeAssert<
         IsExact<
-          Parameters<typeof store.add>[0],
-          'one' | 'two' | 'three' | 'four' | 'five'
+          Parameters<typeof store.add<'five'>>[0],
+          'five'
         >
       >(true);
 
       typeAssert<
         IsExact<
-          Parameters<typeof store.add>[1],
-          1 | 2 | 3 | 4 | 5 | undefined
+          Parameters<typeof store.add<'five'>>[1],
+          5 | undefined
         >
       >(true);
 
@@ -1686,15 +1714,8 @@ suite('IDBPObjectStore', () => {
 
       typeAssert<
         IsExact<
-          Parameters<typeof store.put>[0],
-          'one' | 'two' | 'three' | 'four' | 'five'
-        >
-      >(true);
-
-      typeAssert<
-        IsExact<
-          Parameters<typeof store.put>[1],
-          1 | 2 | 3 | 4 | 5 | undefined
+          Parameters<typeof store.put<'five'>>[0],
+          'five'
         >
       >(true);
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -914,7 +914,7 @@ suite('IDBPObjectStore', () => {
         typeof store2.add,
         (
           value: number,
-          key?: string | IDBKeyRange | undefined,
+          key?: string | undefined,
         ) => Promise<string>
       >
     >(true);
@@ -923,7 +923,7 @@ suite('IDBPObjectStore', () => {
         typeof store2.put,
         (
           value: number,
-          key?: string | IDBKeyRange | undefined,
+          key?: string | undefined,
         ) => Promise<string>
       >
     >(true);
@@ -1014,7 +1014,7 @@ suite('IDBPObjectStore', () => {
     typeAssert<
       IsExact<
         Parameters<typeof store1.add>[1],
-        string | IDBKeyRange | undefined
+        string | undefined
       >
     >(true);
 
@@ -1033,7 +1033,7 @@ suite('IDBPObjectStore', () => {
     typeAssert<
       IsExact<
         Parameters<typeof store2.add>[1],
-        IDBValidKey | IDBKeyRange | undefined
+        IDBValidKey | undefined
       >
     >(true);
 
@@ -1430,7 +1430,7 @@ suite('IDBPObjectStore', () => {
     typeAssert<
       IsExact<
         Parameters<typeof store1.put>[1],
-        string | IDBKeyRange | undefined
+        string | undefined
       >
     >(true);
 
@@ -1449,7 +1449,7 @@ suite('IDBPObjectStore', () => {
     typeAssert<
       IsExact<
         Parameters<typeof store2.put>[1],
-        IDBValidKey | IDBKeyRange | undefined
+        IDBValidKey | undefined
       >
     >(true);
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -1055,57 +1055,91 @@ suite('IDBPObjectStore', () => {
     const schemaDB = await openDBWithData();
     db = schemaDB as IDBPDatabase;
 
-    const store1 = schemaDB.transaction('key-val-store', 'readwrite').store;
+    {
+      const store = schemaDB.transaction('key-val-store', 'readwrite').store;
 
-    typeAssert<IsExact<Parameters<typeof store1.add>[0], number>>(true);
+      typeAssert<IsExact<Parameters<typeof store.add>[0], number>>(true);
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof store1.add>[1],
-        string | undefined
-      >
-    >(true);
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.add>[1],
+          string | undefined
+        >
+      >(true);
 
-    const key = await store1.add(234, 'new');
+      const key = await store.add(234, 'new');
 
-    typeAssert<IsExact<typeof key, string>>(true);
+      typeAssert<IsExact<typeof key, string>>(true);
 
-    const val = await store1.get('new');
+      const val = await store.get('new');
 
-    assert.strictEqual(val, 234, 'Correct value from store');
+      assert.strictEqual(val, 234, 'Correct value from store');
+    }
 
-    const store2 = db.transaction('object-store', 'readwrite').store;
+    {
+      const store = db.transaction('object-store', 'readwrite').store;
 
-    typeAssert<IsExact<Parameters<typeof store2.add>[0], any>>(true);
+      typeAssert<IsExact<Parameters<typeof store.add>[0], any>>(true);
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof store2.add>[1],
-        IDBValidKey | undefined
-      >
-    >(true);
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.add>[1],
+          IDBValidKey | undefined
+        >
+      >(true);
 
-    const key2 = await store2.add({
-      id: 5,
-      title: 'Article 5',
-      date: new Date('2018-05-09'),
-    });
-
-    typeAssert<IsExact<typeof key2, IDBValidKey>>(true);
-
-    const val2 = await store2.get(5);
-
-    typeAssert<IsExact<typeof val2, any>>(true);
-
-    assert.deepStrictEqual(
-      val2,
-      {
+      const key = await store.add({
         id: 5,
         title: 'Article 5',
         date: new Date('2018-05-09'),
-      },
-      'Correct value from store',
-    );
+      });
+
+      typeAssert<IsExact<typeof key, IDBValidKey>>(true);
+
+      const val = await store.get(5);
+
+      typeAssert<IsExact<typeof val, any>>(true);
+
+      assert.deepStrictEqual(
+        val,
+        {
+          id: 5,
+          title: 'Article 5',
+          date: new Date('2018-05-09'),
+        },
+        'Correct value from store',
+      );
+    }
+
+    {
+      const store = schemaDB.transaction('union-store', 'readwrite').store;
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.add>[0],
+          'one' | 'two' | 'three' | 'four' | 'five'
+        >
+      >(true);
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.add>[1],
+          1 | 2 | 3 | 4 | 5 | undefined
+        >
+      >(true);
+
+      const key = await store.add('five', 5);
+
+      typeAssert<IsExact<typeof key, 5>>(true);
+
+      assert.strictEqual(key, 5, 'Correct value from store');
+
+      const val = await store.get(5);
+
+      typeAssert<IsExact<typeof val, 'five' | undefined>>(true);
+
+      assert.strictEqual(val, 'five', 'Correct value from store');
+    }
   });
 
   test('clear', async () => {
@@ -1215,29 +1249,50 @@ suite('IDBPObjectStore', () => {
     const schemaDB = await openDBWithData();
     db = schemaDB as IDBPDatabase;
 
-    const store1 = schemaDB.transaction('key-val-store').store;
+    {
+      const store = schemaDB.transaction('key-val-store').store;
 
-    typeAssert<IsExact<Parameters<typeof store1.get>[0], string | IDBKeyRange>>(
-      true,
-    );
+      typeAssert<IsExact<Parameters<typeof store.get>[0], string | IDBKeyRange>>(
+        true,
+      );
 
-    const val = await store1.get('foo');
+      const val = await store.get('foo');
 
-    typeAssert<IsExact<typeof val, number | undefined>>(true);
+      typeAssert<IsExact<typeof val, number | undefined>>(true);
 
-    assert.strictEqual(val, 123, 'Correct value from store');
+      assert.strictEqual(val, 123, 'Correct value from store');
+    }
 
-    const store2 = db.transaction('key-val-store').store;
+    {
+      const store = db.transaction('key-val-store').store;
 
-    typeAssert<
-      IsExact<Parameters<typeof store2.get>[0], IDBValidKey | IDBKeyRange>
-    >(true);
+      typeAssert<
+        IsExact<Parameters<typeof store.get>[0], IDBValidKey | IDBKeyRange>
+      >(true);
 
-    const val2 = await store2.get('bar');
+      const val = await store.get('bar');
 
-    typeAssert<IsExact<typeof val2, any>>(true);
+      typeAssert<IsExact<typeof val, any>>(true);
 
-    assert.strictEqual(val2, 456, 'Correct value from store');
+      assert.strictEqual(val, 456, 'Correct value from store');
+    }
+
+    {
+      const store = schemaDB.transaction('union-store').store;
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.get>[0],
+          1 | 2 | 3 | 4 | 5 | IDBKeyRange
+        >
+      >(true);
+
+      const val = await store.get(1);
+
+      typeAssert<IsExact<typeof val, 'one' | undefined>>(true);
+
+      assert.strictEqual(val, 'one', 'Correct value from store');
+    }
   });
 
   test('getAll', async function () {
@@ -1245,35 +1300,56 @@ suite('IDBPObjectStore', () => {
     const schemaDB = await openDBWithData();
     db = schemaDB as IDBPDatabase;
 
-    const store1 = schemaDB.transaction('key-val-store').store;
+    {
+      const store = schemaDB.transaction('key-val-store').store;
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof store1.getAll>[0],
-        string | IDBKeyRange | undefined | null
-      >
-    >(true);
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.getAll>[0],
+          string | IDBKeyRange | undefined | null
+        >
+      >(true);
 
-    const val = await store1.getAll();
+      const val = await store.getAll();
 
-    typeAssert<IsExact<typeof val, number[]>>(true);
+      typeAssert<IsExact<typeof val, number[]>>(true);
 
-    assert.deepStrictEqual(val, [456, 123, 789], 'Correct values from store');
+      assert.deepStrictEqual(val, [456, 123, 789], 'Correct values from store');
+    }
 
-    const store2 = db.transaction('key-val-store').store;
+    {
+      const store = db.transaction('key-val-store').store;
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof store2.getAll>[0],
-        IDBValidKey | IDBKeyRange | undefined | null
-      >
-    >(true);
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.getAll>[0],
+          IDBValidKey | IDBKeyRange | undefined | null
+        >
+      >(true);
 
-    const val2 = await store2.getAll();
+      const val = await store.getAll();
 
-    typeAssert<IsExact<typeof val2, any[]>>(true);
+      typeAssert<IsExact<typeof val, any[]>>(true);
 
-    assert.deepStrictEqual(val2, [456, 123, 789], 'Correct values from store');
+      assert.deepStrictEqual(val, [456, 123, 789], 'Correct values from store');
+    }
+
+    {
+      const store = schemaDB.transaction('union-store').store;
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.getAll>[0],
+          1 | 2 | 3 | 4 | 5 | IDBKeyRange | undefined | null
+        >
+      >(true);
+
+      const val = await store.getAll(2);
+
+      typeAssert<IsExact<typeof val, 'two'[]>>(true);
+
+      assert.deepStrictEqual(val, ['two']);
+    }
   });
 
   test('getAllKeys', async function () {
@@ -1281,43 +1357,64 @@ suite('IDBPObjectStore', () => {
     const schemaDB = await openDBWithData();
     db = schemaDB as IDBPDatabase;
 
-    const store1 = schemaDB.transaction('key-val-store').store;
+    {
+      const store = schemaDB.transaction('key-val-store').store;
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof store1.getAllKeys>[0],
-        string | IDBKeyRange | undefined | null
-      >
-    >(true);
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.getAllKeys>[0],
+          string | IDBKeyRange | undefined | null
+        >
+      >(true);
 
-    const val = await store1.getAllKeys();
+      const val = await store.getAllKeys();
 
-    typeAssert<IsExact<typeof val, string[]>>(true);
+      typeAssert<IsExact<typeof val, string[]>>(true);
 
-    assert.deepStrictEqual(
-      val,
-      ['bar', 'foo', 'hello'],
-      'Correct values from store',
-    );
+      assert.deepStrictEqual(
+        val,
+        ['bar', 'foo', 'hello'],
+        'Correct values from store',
+      );
+    }
 
-    const store2 = db.transaction('key-val-store').store;
+    {
+      const store = db.transaction('key-val-store').store;
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof store2.getAllKeys>[0],
-        IDBValidKey | IDBKeyRange | undefined | null
-      >
-    >(true);
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.getAllKeys>[0],
+          IDBValidKey | IDBKeyRange | undefined | null
+        >
+      >(true);
 
-    const val2 = await store2.getAllKeys();
+      const val = await store.getAllKeys();
 
-    typeAssert<IsExact<typeof val2, IDBValidKey[]>>(true);
+      typeAssert<IsExact<typeof val, IDBValidKey[]>>(true);
 
-    assert.deepStrictEqual(
-      val2,
-      ['bar', 'foo', 'hello'],
-      'Correct values from store',
-    );
+      assert.deepStrictEqual(
+        val,
+        ['bar', 'foo', 'hello'],
+        'Correct values from store',
+      );
+    }
+
+    {
+      const store = schemaDB.transaction('union-store').store;
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.getAllKeys>[0],
+          1 | 2 | 3 | 4 | 5 | IDBKeyRange | undefined | null
+        >
+      >(true);
+
+      const val = await store.getAllKeys(3);
+
+      typeAssert<IsExact<typeof val, 3[]>>(true);
+
+      assert.deepStrictEqual(val, [3], 'Correct values from store');
+    }
   });
 
   test('getKey', async function () {
@@ -1325,29 +1422,50 @@ suite('IDBPObjectStore', () => {
     const schemaDB = await openDBWithData();
     db = schemaDB as IDBPDatabase;
 
-    const store1 = schemaDB.transaction('key-val-store').store;
+    {
+      const store = schemaDB.transaction('key-val-store').store;
 
-    typeAssert<
-      IsExact<Parameters<typeof store1.getKey>[0], string | IDBKeyRange>
-    >(true);
+      typeAssert<
+        IsExact<Parameters<typeof store.getKey>[0], string | IDBKeyRange>
+      >(true);
 
-    const val = await store1.getKey(IDBKeyRange.lowerBound('a'));
+      const val = await store.getKey(IDBKeyRange.lowerBound('a'));
 
-    typeAssert<IsExact<typeof val, string | undefined>>(true);
+      typeAssert<IsExact<typeof val, string | undefined>>(true);
 
-    assert.strictEqual(val, 'bar', 'Correct value');
+      assert.strictEqual(val, 'bar', 'Correct value');
+    }
 
-    const store2 = db.transaction('key-val-store').store;
+    {
+      const store = db.transaction('key-val-store').store;
 
-    typeAssert<
-      IsExact<Parameters<typeof store2.getKey>[0], IDBValidKey | IDBKeyRange>
-    >(true);
+      typeAssert<
+        IsExact<Parameters<typeof store.getKey>[0], IDBValidKey | IDBKeyRange>
+      >(true);
 
-    const val2 = await store2.getKey(IDBKeyRange.lowerBound('c'));
+      const val = await store.getKey(IDBKeyRange.lowerBound('c'));
 
-    typeAssert<IsExact<typeof val2, IDBValidKey | undefined>>(true);
+      typeAssert<IsExact<typeof val, IDBValidKey | undefined>>(true);
 
-    assert.strictEqual(val2, 'foo', 'Correct value');
+      assert.strictEqual(val, 'foo', 'Correct value');
+    }
+
+    {
+      const store = schemaDB.transaction('union-store').store;
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.getKey>[0],
+          1 | 2 | 3 | 4 | 5 | IDBKeyRange
+        >
+      >(true);
+
+      const val = await store.getKey(4);
+
+      typeAssert<IsExact<typeof val, 4 | undefined>>(true);
+
+      assert.strictEqual(val, 4, 'Correct value from store');
+    }
   });
 
   test('index', async () => {
@@ -1471,57 +1589,96 @@ suite('IDBPObjectStore', () => {
     const schemaDB = await openDBWithData();
     db = schemaDB as IDBPDatabase;
 
-    const store1 = schemaDB.transaction('key-val-store', 'readwrite').store;
+    {
+      const store = schemaDB.transaction('key-val-store', 'readwrite').store;
 
-    typeAssert<IsExact<Parameters<typeof store1.put>[0], number>>(true);
+      typeAssert<IsExact<Parameters<typeof store.put>[0], number>>(true);
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof store1.put>[1],
-        string | undefined
-      >
-    >(true);
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.put>[1],
+          string | undefined
+        >
+      >(true);
 
-    const key = await store1.put(234, 'new');
+      const key = await store.put(234, 'new');
 
-    typeAssert<IsExact<typeof key, string>>(true);
+      typeAssert<IsExact<typeof key, string>>(true);
 
-    const val = await store1.get('new');
+      const val = await store.get('new');
 
-    assert.strictEqual(val, 234, 'Correct value from store');
+      assert.strictEqual(val, 234, 'Correct value from store');
+    }
 
-    const store2 = db.transaction('object-store', 'readwrite').store;
+    {
+      const store = db.transaction('object-store', 'readwrite').store;
 
-    typeAssert<IsExact<Parameters<typeof store2.put>[0], any>>(true);
+      typeAssert<IsExact<Parameters<typeof store.put>[0], any>>(true);
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof store2.put>[1],
-        IDBValidKey | undefined
-      >
-    >(true);
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.put>[1],
+          IDBValidKey | undefined
+        >
+      >(true);
 
-    const key2 = await store2.put({
-      id: 5,
-      title: 'Article 5',
-      date: new Date('2018-05-09'),
-    });
-
-    typeAssert<IsExact<typeof key2, IDBValidKey>>(true);
-
-    const val2 = await store2.get(5);
-
-    typeAssert<IsExact<typeof val2, any>>(true);
-
-    assert.deepStrictEqual(
-      val2,
-      {
+      const key = await store.put({
         id: 5,
         title: 'Article 5',
         date: new Date('2018-05-09'),
-      },
-      'Correct value from store',
-    );
+      });
+
+      typeAssert<IsExact<typeof key, IDBValidKey>>(true);
+
+      const val = await store.get(5);
+
+      typeAssert<IsExact<typeof val, any>>(true);
+
+      assert.deepStrictEqual(
+        val,
+        {
+          id: 5,
+          title: 'Article 5',
+          date: new Date('2018-05-09'),
+        },
+        'Correct value from store',
+      );
+    }
+
+    {
+      const store = schemaDB.transaction('union-store', 'readwrite').store;
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.put>[0],
+          'one' | 'two' | 'three' | 'four' | 'five'
+        >
+      >(true);
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.put>[1],
+          1 | 2 | 3 | 4 | 5 | undefined
+        >
+      >(true);
+
+      typeAssert<
+        IsExact<
+          Parameters<typeof store.put<'five'>>[1],
+          5 | undefined
+        >
+      >(true);
+
+      const key = await store.put('five', 5);
+
+      typeAssert<IsExact<typeof key, 5>>(true);
+
+      const val = await store.get(5);
+
+      typeAssert<IsExact<typeof val, 'five' | undefined>>(true);
+
+      assert.strictEqual(val, 'five', 'Correct value from store');
+    }
   });
 
   test('wrap', async () => {

--- a/test/main.ts
+++ b/test/main.ts
@@ -42,7 +42,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         typeof schemaDB.objectStoreNames,
-        TypedDOMStringList<'key-val-store' | 'object-store'>
+        TypedDOMStringList<'key-val-store' | 'object-store' | 'union-store'>
       >
     >(true);
 
@@ -58,7 +58,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.createObjectStore>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -74,7 +74,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.deleteObjectStore>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -90,7 +90,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.transaction>[0],
-        ArrayLike<'key-val-store' | 'object-store'>
+        ArrayLike<'key-val-store' | 'object-store' | 'union-store'>
       >
     >(true);
 
@@ -112,7 +112,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         typeof tx.objectStoreNames,
-        TypedDOMStringList<'key-val-store' | 'object-store'>
+        TypedDOMStringList<'key-val-store' | 'object-store' | 'union-store'>
       >
     >(true);
 
@@ -130,7 +130,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.get>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -145,6 +145,12 @@ suite('IDBPDatabase', () => {
     typeAssert<IsExact<typeof val2, any>>(true);
 
     assert.strictEqual(val2, 456, 'Correct value from store');
+
+    const val3 = await schemaDB.get('union-store', 1);
+
+    typeAssert<IsExact<typeof val3, 'one' | undefined>>(true);
+
+    assert.strictEqual(val3, 'one', 'Correct value from store');
   });
 
   test('getFromIndex', async () => {
@@ -195,7 +201,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.getKey>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -213,6 +219,12 @@ suite('IDBPDatabase', () => {
     typeAssert<IsExact<typeof val2, IDBValidKey | undefined>>(true);
 
     assert.strictEqual(val2, 'foo', 'Correct value');
+
+    const val3 = await schemaDB.getKey('union-store', 2);
+
+    typeAssert<IsExact<typeof val3, 2 | undefined>>(true);
+
+    assert.strictEqual(val3, 2, 'Correct value');
   });
 
   test('getKeyFromIndex', async function () {
@@ -253,7 +265,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.getAll>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -268,6 +280,12 @@ suite('IDBPDatabase', () => {
     typeAssert<IsExact<typeof val2, any[]>>(true);
 
     assert.deepStrictEqual(val2, [456, 123, 789], 'Correct values from store');
+
+    const val3 = await schemaDB.getAll('union-store', 3);
+
+    typeAssert<IsExact<typeof val3, 'three'[]>>(true);
+
+    assert.deepStrictEqual(val3, ['three'], 'Correct values from store');
   });
 
   test('getAllFromIndex', async function () {
@@ -349,7 +367,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.getAllKeys>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -372,6 +390,12 @@ suite('IDBPDatabase', () => {
       ['bar', 'foo', 'hello'],
       'Correct values from store',
     );
+
+    const val3 = await schemaDB.getAllKeys('union-store', 4);
+
+    typeAssert<IsExact<typeof val3, 4[]>>(true);
+
+    assert.deepStrictEqual(val3, [4], 'Correct values from store');
   });
 
   test('getAllKeysFromIndex', async function () {
@@ -402,7 +426,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.count>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -450,7 +474,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.put>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -487,6 +511,18 @@ suite('IDBPDatabase', () => {
       },
       'Correct value from store',
     );
+
+    const key3 = await schemaDB.put('union-store', 'five', 5);
+
+    typeAssert<IsExact<typeof key3, 5>>(true);
+
+    assert.strictEqual(key3, 5, 'Correct value from store');
+
+    const val3 = await schemaDB.get('union-store', 5);
+
+    typeAssert<IsExact<typeof val3, 'five' | undefined>>(true);
+
+    assert.strictEqual(val3, 'five', 'Correct value from store');
   });
 
   test('add', async () => {
@@ -498,7 +534,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.add>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -535,6 +571,18 @@ suite('IDBPDatabase', () => {
       },
       'Correct value from store',
     );
+
+    const key3 = await schemaDB.add('union-store', 'five', 5);
+
+    typeAssert<IsExact<typeof key3, 5>>(true);
+
+    assert.strictEqual(key3, 5, 'Correct value from store');
+
+    const val3 = await schemaDB.get('union-store', 5);
+
+    typeAssert<IsExact<typeof val3, 'five' | undefined>>(true);
+
+    assert.strictEqual(val3, 'five', 'Correct value from store');
   });
 
   test('add - error type', async () => {
@@ -593,7 +641,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.delete>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 
@@ -617,7 +665,7 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.clear>[0],
-        'key-val-store' | 'object-store'
+        'key-val-store' | 'object-store' | 'union-store'
       >
     >(true);
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -127,30 +127,36 @@ suite('IDBPDatabase', () => {
 
     assert.property(schemaDB, 'get', 'Method exists');
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof schemaDB.get>[0],
-        'key-val-store' | 'object-store' | 'union-store'
-      >
-    >(true);
+    {
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.get>[0],
+          'key-val-store' | 'object-store' | 'union-store'
+        >
+      >(true);
 
-    const val = await schemaDB.get('key-val-store', 'foo');
+      const val = await schemaDB.get('key-val-store', 'foo');
 
-    typeAssert<IsExact<typeof val, number | undefined>>(true);
+      typeAssert<IsExact<typeof val, number | undefined>>(true);
 
-    assert.strictEqual(val, 123, 'Correct value from store');
+      assert.strictEqual(val, 123, 'Correct value from store');
+    }
 
-    const val2 = await db.get('key-val-store', 'bar');
+    {
+      const val = await db.get('key-val-store', 'bar');
 
-    typeAssert<IsExact<typeof val2, any>>(true);
+      typeAssert<IsExact<typeof val, any>>(true);
 
-    assert.strictEqual(val2, 456, 'Correct value from store');
+      assert.strictEqual(val, 456, 'Correct value from store');
+    }
 
-    const val3 = await schemaDB.get('union-store', 1);
+    {
+      const val = await schemaDB.get('union-store', 1);
 
-    typeAssert<IsExact<typeof val3, 'one' | undefined>>(true);
+      typeAssert<IsExact<typeof val, 'one' | undefined>>(true);
 
-    assert.strictEqual(val3, 'one', 'Correct value from store');
+      assert.strictEqual(val, 'one', 'Correct value from store');
+    }
   });
 
   test('getFromIndex', async () => {
@@ -198,33 +204,39 @@ suite('IDBPDatabase', () => {
 
     assert.property(schemaDB, 'getKey', 'Method exists');
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof schemaDB.getKey>[0],
-        'key-val-store' | 'object-store' | 'union-store'
-      >
-    >(true);
+    {
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.getKey>[0],
+          'key-val-store' | 'object-store' | 'union-store'
+        >
+      >(true);
 
-    const val = await schemaDB.getKey(
-      'key-val-store',
-      IDBKeyRange.lowerBound('a'),
-    );
+      const val = await schemaDB.getKey(
+        'key-val-store',
+        IDBKeyRange.lowerBound('a'),
+      );
 
-    typeAssert<IsExact<typeof val, string | undefined>>(true);
+      typeAssert<IsExact<typeof val, string | undefined>>(true);
 
-    assert.strictEqual(val, 'bar', 'Correct value');
+      assert.strictEqual(val, 'bar', 'Correct value');
+    }
 
-    const val2 = await db.getKey('key-val-store', IDBKeyRange.lowerBound('c'));
+    {
+      const val = await db.getKey('key-val-store', IDBKeyRange.lowerBound('c'));
 
-    typeAssert<IsExact<typeof val2, IDBValidKey | undefined>>(true);
+      typeAssert<IsExact<typeof val, IDBValidKey | undefined>>(true);
 
-    assert.strictEqual(val2, 'foo', 'Correct value');
+      assert.strictEqual(val, 'foo', 'Correct value');
+    }
 
-    const val3 = await schemaDB.getKey('union-store', 2);
+    {
+      const val = await schemaDB.getKey('union-store', 2);
 
-    typeAssert<IsExact<typeof val3, 2 | undefined>>(true);
+      typeAssert<IsExact<typeof val, 2 | undefined>>(true);
 
-    assert.strictEqual(val3, 2, 'Correct value');
+      assert.strictEqual(val, 2, 'Correct value');
+    }
   });
 
   test('getKeyFromIndex', async function () {
@@ -262,30 +274,36 @@ suite('IDBPDatabase', () => {
 
     assert.property(schemaDB, 'getAll', 'Method exists');
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof schemaDB.getAll>[0],
-        'key-val-store' | 'object-store' | 'union-store'
-      >
-    >(true);
+    {
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.getAll>[0],
+          'key-val-store' | 'object-store' | 'union-store'
+        >
+      >(true);
 
-    const val = await schemaDB.getAll('key-val-store');
+      const val = await schemaDB.getAll('key-val-store');
 
-    typeAssert<IsExact<typeof val, number[]>>(true);
+      typeAssert<IsExact<typeof val, number[]>>(true);
 
-    assert.deepStrictEqual(val, [456, 123, 789], 'Correct values from store');
+      assert.deepStrictEqual(val, [456, 123, 789], 'Correct values from store');
+    }
 
-    const val2 = await db.getAll('key-val-store');
+    {
+      const val = await db.getAll('key-val-store');
 
-    typeAssert<IsExact<typeof val2, any[]>>(true);
+      typeAssert<IsExact<typeof val, any[]>>(true);
 
-    assert.deepStrictEqual(val2, [456, 123, 789], 'Correct values from store');
+      assert.deepStrictEqual(val, [456, 123, 789], 'Correct values from store');
+    }
 
-    const val3 = await schemaDB.getAll('union-store', 3);
+    {
+      const val = await schemaDB.getAll('union-store', 3);
 
-    typeAssert<IsExact<typeof val3, 'three'[]>>(true);
+      typeAssert<IsExact<typeof val, 'three'[]>>(true);
 
-    assert.deepStrictEqual(val3, ['three'], 'Correct values from store');
+      assert.deepStrictEqual(val, ['three'], 'Correct values from store');
+    }
   });
 
   test('getAllFromIndex', async function () {
@@ -364,38 +382,44 @@ suite('IDBPDatabase', () => {
 
     assert.property(schemaDB, 'getAllKeys', 'Method exists');
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof schemaDB.getAllKeys>[0],
-        'key-val-store' | 'object-store' | 'union-store'
-      >
-    >(true);
+    {
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.getAllKeys>[0],
+          'key-val-store' | 'object-store' | 'union-store'
+        >
+      >(true);
 
-    const val = await schemaDB.getAllKeys('key-val-store');
+      const val = await schemaDB.getAllKeys('key-val-store');
 
-    typeAssert<IsExact<typeof val, string[]>>(true);
+      typeAssert<IsExact<typeof val, string[]>>(true);
 
-    assert.deepStrictEqual(
-      val,
-      ['bar', 'foo', 'hello'],
-      'Correct values from store',
-    );
+      assert.deepStrictEqual(
+        val,
+        ['bar', 'foo', 'hello'],
+        'Correct values from store',
+      );
+    }
 
-    const val2 = await db.getAllKeys('key-val-store');
+    {
+      const val = await db.getAllKeys('key-val-store');
 
-    typeAssert<IsExact<typeof val2, IDBValidKey[]>>(true);
+      typeAssert<IsExact<typeof val, IDBValidKey[]>>(true);
 
-    assert.deepStrictEqual(
-      val2,
-      ['bar', 'foo', 'hello'],
-      'Correct values from store',
-    );
+      assert.deepStrictEqual(
+        val,
+        ['bar', 'foo', 'hello'],
+        'Correct values from store',
+      );
+    }
 
-    const val3 = await schemaDB.getAllKeys('union-store', 4);
+    {
+      const val = await schemaDB.getAllKeys('union-store', 4);
 
-    typeAssert<IsExact<typeof val3, 4[]>>(true);
+      typeAssert<IsExact<typeof val, 4[]>>(true);
 
-    assert.deepStrictEqual(val3, [4], 'Correct values from store');
+      assert.deepStrictEqual(val, [4], 'Correct values from store');
+    }
   });
 
   test('getAllKeysFromIndex', async function () {
@@ -471,58 +495,64 @@ suite('IDBPDatabase', () => {
 
     assert.property(schemaDB, 'put', 'Method exists');
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof schemaDB.put>[0],
-        'key-val-store' | 'object-store' | 'union-store'
-      >
-    >(true);
+    {
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.put>[0],
+          'key-val-store' | 'object-store' | 'union-store'
+        >
+      >(true);
 
-    const key = await schemaDB.put('key-val-store', 234, 'new');
+      const key = await schemaDB.put('key-val-store', 234, 'new');
 
-    typeAssert<IsExact<typeof key, string>>(true);
+      typeAssert<IsExact<typeof key, string>>(true);
 
-    assert.strictEqual(key, 'new');
+      assert.strictEqual(key, 'new');
 
-    const val = await schemaDB.get('key-val-store', 'new');
+      const val = await schemaDB.get('key-val-store', 'new');
 
-    assert.strictEqual(val, 234, 'Correct value from store');
+      assert.strictEqual(val, 234, 'Correct value from store');
+    }
 
-    const key2 = await db.put('object-store', {
-      id: 5,
-      title: 'Article 5',
-      date: new Date('2018-05-09'),
-    });
-
-    typeAssert<IsExact<typeof key2, IDBValidKey>>(true);
-
-    assert.strictEqual(key2, 5);
-
-    const val2 = await db.get('object-store', 5);
-
-    typeAssert<IsExact<typeof val2, any>>(true);
-
-    assert.deepStrictEqual(
-      val2,
-      {
+    {
+      const key = await db.put('object-store', {
         id: 5,
         title: 'Article 5',
         date: new Date('2018-05-09'),
-      },
-      'Correct value from store',
-    );
+      });
 
-    const key3 = await schemaDB.put('union-store', 'five', 5);
+      typeAssert<IsExact<typeof key, IDBValidKey>>(true);
 
-    typeAssert<IsExact<typeof key3, 5>>(true);
+      assert.strictEqual(key, 5);
 
-    assert.strictEqual(key3, 5, 'Correct value from store');
+      const val = await db.get('object-store', 5);
 
-    const val3 = await schemaDB.get('union-store', 5);
+      typeAssert<IsExact<typeof val, any>>(true);
 
-    typeAssert<IsExact<typeof val3, 'five' | undefined>>(true);
+      assert.deepStrictEqual(
+        val,
+        {
+          id: 5,
+          title: 'Article 5',
+          date: new Date('2018-05-09'),
+        },
+        'Correct value from store',
+      );
+    }
 
-    assert.strictEqual(val3, 'five', 'Correct value from store');
+    {
+      const key = await schemaDB.put('union-store', 'five', 5);
+
+      typeAssert<IsExact<typeof key, 5>>(true);
+
+      assert.strictEqual(key, 5, 'Correct value from store');
+
+      const val = await schemaDB.get('union-store', 5);
+
+      typeAssert<IsExact<typeof val, 'five' | undefined>>(true);
+
+      assert.strictEqual(val, 'five', 'Correct value from store');
+    }
   });
 
   test('add', async () => {
@@ -531,58 +561,64 @@ suite('IDBPDatabase', () => {
 
     assert.property(schemaDB, 'add', 'Method exists');
 
-    typeAssert<
-      IsExact<
-        Parameters<typeof schemaDB.add>[0],
-        'key-val-store' | 'object-store' | 'union-store'
-      >
-    >(true);
+    {
+      typeAssert<
+        IsExact<
+          Parameters<typeof schemaDB.add>[0],
+          'key-val-store' | 'object-store' | 'union-store'
+        >
+      >(true);
 
-    const key = await schemaDB.add('key-val-store', 234, 'new');
+      const key = await schemaDB.add('key-val-store', 234, 'new');
 
-    typeAssert<IsExact<typeof key, string>>(true);
+      typeAssert<IsExact<typeof key, string>>(true);
 
-    assert.strictEqual(key, 'new');
+      assert.strictEqual(key, 'new');
 
-    const val = await schemaDB.get('key-val-store', 'new');
+      const val = await schemaDB.get('key-val-store', 'new');
 
-    assert.strictEqual(val, 234, 'Correct value from store');
+      assert.strictEqual(val, 234, 'Correct value from store');
+    }
 
-    const key2 = await db.add('object-store', {
-      id: 5,
-      title: 'Article 5',
-      date: new Date('2018-05-09'),
-    });
-
-    typeAssert<IsExact<typeof key2, IDBValidKey>>(true);
-
-    assert.strictEqual(key2, 5);
-
-    const val2 = await db.get('object-store', 5);
-
-    typeAssert<IsExact<typeof val2, any>>(true);
-
-    assert.deepStrictEqual(
-      val2,
-      {
+    {
+      const key = await db.add('object-store', {
         id: 5,
         title: 'Article 5',
         date: new Date('2018-05-09'),
-      },
-      'Correct value from store',
-    );
+      });
 
-    const key3 = await schemaDB.add('union-store', 'five', 5);
+      typeAssert<IsExact<typeof key, IDBValidKey>>(true);
 
-    typeAssert<IsExact<typeof key3, 5>>(true);
+      assert.strictEqual(key, 5);
 
-    assert.strictEqual(key3, 5, 'Correct value from store');
+      const val = await db.get('object-store', 5);
 
-    const val3 = await schemaDB.get('union-store', 5);
+      typeAssert<IsExact<typeof val, any>>(true);
 
-    typeAssert<IsExact<typeof val3, 'five' | undefined>>(true);
+      assert.deepStrictEqual(
+        val,
+        {
+          id: 5,
+          title: 'Article 5',
+          date: new Date('2018-05-09'),
+        },
+        'Correct value from store',
+      );
+    }
 
-    assert.strictEqual(val3, 'five', 'Correct value from store');
+    {
+      const key = await schemaDB.add('union-store', 'five', 5);
+
+      typeAssert<IsExact<typeof key, 5>>(true);
+
+      assert.strictEqual(key, 5, 'Correct value from store');
+
+      const val = await schemaDB.get('union-store', 5);
+
+      typeAssert<IsExact<typeof val, 'five' | undefined>>(true);
+
+      assert.strictEqual(val, 'five', 'Correct value from store');
+    }
   });
 
   test('add - error type', async () => {

--- a/test/open.ts
+++ b/test/open.ts
@@ -37,7 +37,7 @@ suite('openDb', () => {
             typeof tx,
             IDBPTransaction<
               TestDBSchema,
-              ('key-val-store' | 'object-store')[],
+              ('key-val-store' | 'object-store' | 'union-store')[],
               'versionchange'
             >
           >
@@ -220,7 +220,7 @@ suite('deleteDb', () => {
 
   test('deleteDb', async () => {
     db = (await openDBWithSchema()) as IDBPDatabase;
-    assert.lengthOf(db.objectStoreNames, 2, 'DB has two stores');
+    assert.lengthOf(db.objectStoreNames, 3, 'DB has three stores');
     db.close();
     await deleteDatabase();
     db = await openDB(dbName, getNextVersion());

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -22,6 +22,27 @@ export interface TestDBSchema extends DBSchema {
     key: number;
     indexes: { date: Date; title: string };
   };
+  'union-store':
+    | {
+        key: 1;
+        value: 'one';
+      }
+    | {
+        key: 2;
+        value: 'two';
+      }
+    | {
+        key: 3;
+        value: 'three';
+      }
+    | {
+        key: 4;
+        value: 'four';
+      }
+    | {
+        key: 5;
+        value: 'five';
+      };
 }
 
 export const dbName = 'test-db';
@@ -43,6 +64,7 @@ export function openDBWithSchema(): Promise<IDBPDatabase<TestDBSchema>> {
       const store = db.createObjectStore('object-store', { keyPath: 'id' });
       store.createIndex('date', 'date');
       store.createIndex('title', 'title');
+      db.createObjectStore('union-store');
     },
   });
 }
@@ -53,9 +75,13 @@ export async function openDBWithData() {
   if (dbWithDataCreated) return openDB<TestDBSchema>(dbName, version);
   dbWithDataCreated = true;
   const db = await openDBWithSchema();
-  const tx = db.transaction(['key-val-store', 'object-store'], 'readwrite');
+  const tx = db.transaction(
+    ['key-val-store', 'object-store', 'union-store'],
+    'readwrite',
+  );
   const keyStore = tx.objectStore('key-val-store');
   const objStore = tx.objectStore('object-store');
+  const unionStore = tx.objectStore('union-store');
   keyStore.put(123, 'foo');
   keyStore.put(456, 'bar');
   keyStore.put(789, 'hello');
@@ -79,6 +105,10 @@ export async function openDBWithData() {
     title: 'Article 4',
     date: new Date('2019-01-01'),
   });
+  unionStore.put('one', 1);
+  unionStore.put('two', 2);
+  unionStore.put('three', 3);
+  unionStore.put('four', 4);
   return db;
 }
 


### PR DESCRIPTION
This makes some changes to the type declarations so that the value type of an object store can be narrowed based on the key type (and vice versa).

```ts
interface Schema extends DBSchema {
  store: {
    key: 'foo';
    value: string;
  } | {
    key: 'bar';
    value: number;
  };
}

// Type of `foo` before this PR:
//   string | number | undefined
// Type of `foo` after this PR:
//   string | undefined
const foo = await db.get('store', 'foo');

// Both of these are fine before this PR but fail to compile after this PR.
await db.put('store', 'string', 'bar');
await db.put('store', 1234, 'foo');
```

There are some caveats. There's a limitation in the way that TypeScript unions work (see [microsoft/TypeScript#18758](https://github.com/microsoft/TypeScript/issues/18758)). It means that the type changes made in this PR cannot be applied to indexes. It also means that narrowing the key type based on a value type when the value type is an object type isn't possible (which affects the typing of `add` and `put`).

Also, cursor types haven't been updated. Creating a cursor over one value (for example `'foo'`) and expecting the value type to be narrowed (`string` instead of `string | number`) seems like an obscure use-case. It didn't seem worth the added complexity but I'll implement it if requested. A more common use case would be iterating over multiple values for a single key in an index but we can't do that.

Resolves #275.