### PR TITLE
cleanup workarounds for Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IndexedDB with usability.
 
-This is a tiny (~1.06kB brotli'd) library that mostly mirrors the IndexedDB API, but with small improvements that make a big difference to usability.
+This is a tiny (~1.29kB brotli'd) library that mostly mirrors the IndexedDB API, but with small improvements that make a big difference to usability.
 
 1. [Installation](#installation)
 1. [Changes](#changes)
@@ -151,8 +151,6 @@ const wrapped = wrap(unwrapped);
 
 This is useful if some third party code gives you an `IDBDatabase` object and you want it to have the features of this library.
 
-This doesn't work with `IDBCursor`, [due to missing primitives](https://github.com/w3c/IndexedDB/issues/255). Also, if you wrap an `IDBTransaction`, `tx.store` and `tx.objectStoreNames` won't work in Edge. To avoid these issues, wrap the `IDBDatabase` object, and use the wrapped object to create a new transaction.
-
 ## General enhancements
 
 Once you've opened the database the API is the same as IndexedDB, except for a few changes to make things easier.
@@ -270,15 +268,7 @@ while (cursor) {
 
 ## Async iterators
 
-Async iterator support isn't included by default (Edge doesn't support them). To include them, import `idb/with-async-ittr` instead of `idb` (this increases the library size to ~1.29kB brotli'd):
-
-```js
-import { openDB } from 'idb/with-async-ittr';
-```
-
-Or `https://cdn.jsdelivr.net/npm/idb@7/build/umd-with-async-ittr.js` if you're using the non-module version.
-
-Now you can iterate over stores, indexes, and cursors:
+You can iterate over stores, indexes, and cursors:
 
 ```js
 const tx = db.transaction(storeName);

--- a/package.json
+++ b/package.json
@@ -12,12 +12,6 @@
       "import": "./build/index.js",
       "default": "./build/index.cjs"
     },
-    "./with-async-ittr": {
-      "types": "./with-async-ittr.d.ts",
-      "module": "./with-async-ittr.js",
-      "import": "./with-async-ittr.js",
-      "default": "./with-async-ittr.cjs"
-    },
     "./build/*": "./build/*",
     "./package.json": "./package.json"
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,7 +20,7 @@ export default async function ({ watch }) {
   // Main
   builds.push({
     plugins: [simpleTS('test', { watch })],
-    input: ['src/index.ts', 'src/async-iterators.ts'],
+    input: ['src/index.ts'],
     output: [
       {
         dir: 'build/',
@@ -47,22 +47,6 @@ export default async function ({ watch }) {
     ],
     output: {
       file: 'build/umd.js',
-      format: 'umd',
-      esModule: false,
-      name: 'idb',
-    },
-  });
-
-  // Minified iife including iteration
-  builds.push({
-    input: './with-async-ittr.js',
-    plugins: [
-      terser({
-        compress: { ecma: 2019 },
-      }),
-    ],
-    output: {
-      file: 'build/umd-with-async-ittr.js',
       format: 'umd',
       esModule: false,
       name: 'idb',

--- a/size-tests/with-async-ittr.js
+++ b/size-tests/with-async-ittr.js
@@ -1,2 +1,0 @@
-import { openDB } from '../with-async-ittr';
-a(openDB);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './entry.js';
 import './database-extras.js';
+import './async-iterators.js';

--- a/with-async-ittr.cjs
+++ b/with-async-ittr.cjs
@@ -1,2 +1,0 @@
-module.exports = require('./build/index.cjs');
-require('./build/async-iterators.cjs');

--- a/with-async-ittr.d.ts
+++ b/with-async-ittr.d.ts
@@ -1,1 +1,0 @@
-export * from './build/index.js';

--- a/with-async-ittr.js
+++ b/with-async-ittr.js
@@ -1,2 +1,0 @@
-export * from './build/index.js';
-import './build/async-iterators.js';


### PR DESCRIPTION
related to #274 and #255

tests are working in Edge (ran on [StackBlitz](https://pr.new/github.com/musakui/idb/tree/edge-cleanup))

if bundle size is an issue, would an opt-out version (e.g. `idb/without-async-ittr`) work?
