### PR TITLE
Update DB error handling to reject with Error objects

### DIFF
--- a/src/wrap-idb-value.ts
+++ b/src/wrap-idb-value.ts
@@ -55,7 +55,7 @@ function promisifyRequest<T>(request: IDBRequest<T>): Promise<T> {
       unlisten();
     };
     const error = () => {
-      reject(request.error);
+      new Error('IDBRequest error', {cause: request!.error}));
       unlisten();
     };
     request.addEventListener('success', success);
@@ -83,7 +83,9 @@ function cacheDonePromiseForTransaction(tx: IDBTransaction): void {
       unlisten();
     };
     const error = () => {
-      reject(tx.error || new DOMException('AbortError', 'AbortError'));
+      reject(new Error(
+          'IDBTransaction Error',
+          {cause: tx.error || new DOMException('AbortError', 'AbortError')}));
       unlisten();
     };
     tx.addEventListener('complete', complete);


### PR DESCRIPTION
Promise rejections generate [PromiseRejectionEvents](https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent) (PREs).  PREs allow specifying a `reason`. 
Rejecting with an Error object improves debugging because the Error will contain an Error message and stack trace. [DOMExceptions](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) and [DOMErrors](https://developer.mozilla.org/en-US/docs/Web/API/DOMError) do not extend Error but can be passed as the underlying cause in the Error to retain the original IDB request or transaction error details.