### PR TITLE
Fix DOMStringList compatibility

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -251,6 +251,8 @@ type IDBPDatabaseExtends = Omit<
   'createObjectStore' | 'deleteObjectStore' | 'transaction' | 'objectStoreNames'
 >;
 
+export type DOMStringListSymbolIteratorType = DOMStringList extends { [Symbol.iterator](): infer R } ? R : IterableIterator<string>;
+
 /**
  * A variation of DOMStringList with precise string types
  */
@@ -258,7 +260,12 @@ export interface TypedDOMStringList<T extends string> extends DOMStringList {
   contains(string: T): boolean;
   item(index: number): T | null;
   [index: number]: T;
-  [Symbol.iterator](): IterableIterator<T>;
+
+  /**
+   * To resolve https://github.com/jakearchibald/idb/issues/327,
+   * and for compatibility with TypeScript >= 5.6 with ArrayIterator.
+   */
+  [Symbol.iterator](): IterableIterator<string> extends DOMStringListSymbolIteratorType ? IterableIterator<T> : DOMStringListSymbolIteratorType & Iterator<T>;
 }
 
 interface IDBTransactionOptions {


### PR DESCRIPTION
To resolve https://github.com/jakearchibald/idb/issues/327.

## Background

TypeScript 5.6 introduces `ArrayIterator` and uses it in the DOM types:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-6.html#iterator-helper-methods

Specifically, the type of the `[Symbol.iterator]` method on` DOMStringLis`t has changed from `IterableIterator<string>` to `ArrayIterator<string>`, which is available when the `dom.iterable` lib is enabled.
Since `ArrayIterator` and `IterableIterator` are not compatible, this change can lead to type errors.

See https://github.com/mizunashi-mana/idb-issue327-example for a minimal reproduction of the issue.

## Description of resolution

* Use `IterableIterator` for TypeScript < 5.6, as before.
* Use the intersection type of `Iterator` and the original type of `DOMString` for TypeScript >= 5.6
    - We cannot use `ArrayIterator` for TypeScript < 5.6 which `ArrayIterator` is not available on.
    - It works in the case: https://github.com/mizunashi-mana/idb-issue327-example/blob/main/src/main.ts.

## Alternative

* Use `ArrayIterator<T>` and drop TypeScript < 5.6.