### PR TITLE
improve: improve the transaction method storeNames parameter type

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -307,21 +307,21 @@ export interface IDBPDatabase<DBTypes extends DBSchema | unknown = unknown>
    * @param options
    */
   transaction<
-    Name extends StoreNames<DBTypes>,
-    Mode extends IDBTransactionMode = 'readonly',
-  >(
-    storeNames: Name,
-    mode?: Mode,
-    options?: IDBTransactionOptions,
-  ): IDBPTransaction<DBTypes, [Name], Mode>;
-  transaction<
-    Names extends ArrayLike<StoreNames<DBTypes>>,
+    Names extends StoreNames<DBTypes> | ArrayLike<StoreNames<DBTypes>>,
     Mode extends IDBTransactionMode = 'readonly',
   >(
     storeNames: Names,
     mode?: Mode,
     options?: IDBTransactionOptions,
-  ): IDBPTransaction<DBTypes, Names, Mode>;
+  ): IDBPTransaction<
+    DBTypes,
+    Names extends StoreNames<DBTypes>
+      ? [Names]
+      : Names extends ArrayLike<StoreNames<DBTypes>>
+        ? Names
+        : never,
+    Mode
+  >;
 
   // Shortcut methods
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -87,7 +87,9 @@ suite('IDBPDatabase', () => {
     typeAssert<
       IsExact<
         Parameters<typeof schemaDB.transaction>[0],
-        ArrayLike<'key-val-store' | 'object-store'>
+        | 'key-val-store'
+        | 'object-store'
+        | ArrayLike<'key-val-store' | 'object-store'>
       >
     >(true);
 


### PR DESCRIPTION
When the storeNames parameter is an array, there is no type prompt in the recommendation.

**before**
![image](https://github.com/user-attachments/assets/8e0a42c2-621b-40fb-b97d-acb2d47fe7b3)
![image](https://github.com/user-attachments/assets/e49e6a37-bd4f-47f0-9778-f4222bc5e0d3)

**after**
![image](https://github.com/user-attachments/assets/4337f22e-590b-49c2-8654-091ee402dc73)
![image](https://github.com/user-attachments/assets/b53c2d24-ce14-4c33-bea9-cdf26a980c8d)